### PR TITLE
Migrate Chart.yaml annotations to new format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Migrate Chart.yaml annotations to new format as per https://docs.giantswarm.io/reference/platform-api/chart-metadata/
+
 ## [0.1.0] - 2024-07-24
 
 - initial release compatible with vintage and CAPI
 
 [Unreleased]: https://github.com/giantswarm/kratix-app/compare/v0.1.0...HEAD
+
+### Changed
+
+- Migrate Chart.yaml annotations to new format as per https://docs.giantswarm.io/reference/platform-api/chart-metadata/
 [0.1.0]: https://github.com/giantswarm/kratix-app/releases/tag/v0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [Unreleased]: https://github.com/giantswarm/kratix-app/compare/v0.1.0...HEAD
 
-### Changed
-
-- Migrate Chart.yaml annotations to new format as per https://docs.giantswarm.io/reference/platform-api/chart-metadata/
 [0.1.0]: https://github.com/giantswarm/kratix-app/releases/tag/v0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Migrate Chart.yaml annotations to new format as per https://docs.giantswarm.io/reference/platform-api/chart-metadata/
-
 ## [0.1.0] - 2024-07-24
 
 - initial release compatible with vintage and CAPI
 
 [Unreleased]: https://github.com/giantswarm/kratix-app/compare/v0.1.0...HEAD
-
 [0.1.0]: https://github.com/giantswarm/kratix-app/releases/tag/v0.1.0

--- a/helm/kratix/Chart.yaml
+++ b/helm/kratix/Chart.yaml
@@ -1,32 +1,15 @@
 apiVersion: v2
 name: kratix
 description: A Helm chart for installing Kratix (https://kratix.io)
-# A chart can be either an 'application' or a 'library' chart.
-#
-# Application charts are a collection of templates that can be packaged into versioned archives
-# to be deployed.
-#
-# Library charts provide useful utilities or functions for the chart developer. They're included as
-# a dependency of application charts to inject those utilities and functions into the rendering
-# pipeline. Library charts do not define any templates and therefore cannot be deployed.
 type: application
-# This is the chart version. This version number should be incremented each time you make changes
-# to the chart and its templates, including the app version.
-# Versions are expected to follow Semantic Versioning (https://semver.org/)
 version: 0.1.0
-# This is the version number of the application being deployed. This version number should be
-# incremented each time you make changes to the application. Versions are not expected to
-# follow Semantic Versioning. They should reflect the version the application is using.
-# It is recommended to use it with quotes.
-appVersion: "1.16.0"
+appVersion: 1.16.0
 keywords:
-  - platform
+- platform
 home: https://kratix.io/
 icon: https://s.giantswarm.io/app-icons/kratix/1/light.png
 annotations:
-  application.giantswarm.io/team: "honeybadger"
-  config.giantswarm.io/version: 1.x.x
-restrictions:
-  clusterSingleton: true
-  namespaceSingleton: false
+  io.giantswarm.application.restrictions.cluster-singleton: 'true'
+  io.giantswarm.application.restrictions.namespace-singleton: 'false'
+  io.giantswarm.application.team: honeybadger
 upstreamChartVersion: 0.125.0

--- a/helm/kratix/templates/_helpers.tpl
+++ b/helm/kratix/templates/_helpers.tpl
@@ -6,5 +6,5 @@ Common labels
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
-application.giantswarm.io/team: {{ index .Chart.Annotations "application.giantswarm.io/team" | quote }}
+application.giantswarm.io/team: {{ index .Chart.Annotations "io.giantswarm.application.team" | quote }}
 {{- end }}


### PR DESCRIPTION
This PR migrates the Chart.yaml metadata to use Giant Swarm's new annotation format.

Changes:
- Set apiVersion to v2
- Convert `restrictions` field to annotations with new keys (io.giantswarm.application.restrictions.*)
- Migrate annotation keys to new format (io.giantswarm.application.*)
- Remove deprecated `config.giantswarm.io/version` annotation
- Update template files to use new annotation keys
- Update architect-orb to version 6.10.0 or higher

Reference: https://docs.giantswarm.io/reference/platform-api/chart-metadata/